### PR TITLE
Update issue template to point to JIRA

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,42 +1,24 @@
-# Issue Details
+            uuuuuuuuuuuuuuuuuuuu
+          u" uuuuuuuuuuuuuuuuuu "u
+        u" u$$$$$$$$$$$$$$$$$$$$u "u
+      u" u$$$$$$$$$$$$$$$$$$$$$$$$u "u
+    u" u$$$$$$$$$$$$$$$$$$$$$$$$$$$$u "u
+  u" u$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$u "u
+u" u$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$u "u
+$ $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ $
+$ $$$" ... "$...  ...$" ... "$$$  ... "$$$ $
+$ $$$u `"$$$$$$$  $$$  $$$$$  $$  $$$  $$$ $
+$ $$$$$$uu "$$$$  $$$  $$$$$  $$  """ u$$$ $
+$ $$$""$$$  $$$$  $$$u "$$$" u$$  $$$$$$$$ $
+$ $$$$....,$$$$$..$$$$$....,$$$$..$$$$$$$$ $
+$ $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ $
+"u "$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$" u"
+  "u "$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$" u"
+    "u "$$$$$$$$$$$$$$$$$$$$$$$$$$$$" u"
+      "u "$$$$$$$$$$$$$$$$$$$$$$$$" u"
+        "u "$$$$$$$$$$$$$$$$$$$$" u"
+          "u """""""""""""""""" u"
+            """"""""""""""""""""
 
-
-### Screenshots / Design Comps <i>(Optional)</i>
-
-
-# Acceptance Criteria
-REPLACE THIS LINE WITH A DESCRIPTION OF HOW A USER OR AN AUTOMATED TEST WOULD ASSERT THAT THIS FEATURE IS "CORRECT"
-
-<details>
-  <summary><b>Stakeholder Information</b> <i>(Optional)</i></summary>
-
-+ <b>This issue was requested by (use Code Name):</b> MERLIN
-+ <b>Internal stakeholders who need to sign off on this issue:</b>
-    - Andrew Aslinger
-    - Derek Daczewitz
-    - Matt Dykstra
-    - Brian Fort
-    - Loosiné Vartani
-
-</details>
-
-# Issue Creation Checklist
-+ [ ] I have provided a description of this issue
-    - If a bug, include reproduction steps
-    - If a feature request, include a stakeholder
-+ [ ] I have provided acceptance criteria
-+ [ ] I have described how to test this issue
-+ [ ] I have documented who requested this issue
-+ [ ] I have provided a list of internal stakeholders who must "accept" this issue as being complete
-+ [ ] I have labeled this issue with a type (bug, enhancement, security, tech debt, etc.)
-
-<details>
-  <summary><b>Optional Steps Checklist:</b></summary>
-
-- [ ] I have labeled this issue with a priority (high, medium, low)
-- [ ] I have provided a deadline for this issue in the Issue Details section
-- [ ] I have provided _annotated_ screenshot(s), mockup(s), or diagram(s) describing the feature or issue
-- [ ] I have provided Kibana logs detailing the error message
-- [ ] I have provided [semantic versioning](https://semver.org) guidance for this issue (major, minor, or patch)
-
-</details>
+Please log on to the VPN and place all issues in JIRA:
+https://jira.spaceflightindustries.com/secure/RapidBoard.jspa?projectKey=PLAT

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,4 @@
+```
             uuuuuuuuuuuuuuuuuuuu
           u" uuuuuuuuuuuuuuuuuu "u
         u" u$$$$$$$$$$$$$$$$$$$$u "u
@@ -19,6 +20,7 @@ $ $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ $
         "u "$$$$$$$$$$$$$$$$$$$$" u"
           "u """""""""""""""""" u"
             """"""""""""""""""""
+```
 
 Please log on to the VPN and place all issues in JIRA:
 https://jira.spaceflightindustries.com/secure/RapidBoard.jspa?projectKey=PLAT


### PR DESCRIPTION
This PR updates the default issue template for all Github issues to encourage people to post in JIRA instead.